### PR TITLE
This will fix the backup rotation bug due to incorrect string in the file name

### DIFF
--- a/backup-mysql.sh
+++ b/backup-mysql.sh
@@ -45,7 +45,7 @@ function local_remote
 
 function local_only
 {
-	mysqldump -u$USER -p$PASS $DBNAME  | gzip > $BACKUP_DIR/$DBNAME-sql-$DATE.sql.gz
+	mysqldump -u$USER -p$PASS $DBNAME  | gzip > $BACKUP_DIR/$DBNAME-mysql-$DATE.sql.gz
 	cd $BACKUP_DIR/
 	ls -t | grep $DBNAME | grep mysql | grep daily | sed -e 1,"$BACKUP_RETENTION_DAILY"d | xargs -d '\n' rm -R > /dev/null 2>&1
 	ls -t | grep $DBNAME | grep mysql | grep weekly | sed -e 1,"$BACKUP_RETENTION_WEEKLY"d | xargs -d '\n' rm -R > /dev/null 2>&1


### PR DESCRIPTION
Grep command in the backup rotation will fail due to incorrect search string.